### PR TITLE
node/express decorates errors msgs with html doctype under linux debian

### DIFF
--- a/src/app/routes/_authentication.spec.js
+++ b/src/app/routes/_authentication.spec.js
@@ -127,7 +127,7 @@ describe('Authentication Routes', () => {
         })
         .expect(401)
         .end((err, res) => {
-          expect(res.text).to.equal('Invalid email length.\n');
+          expect(res.text).to.contain('Invalid email length.');
           done(err);
         });
     });
@@ -141,7 +141,7 @@ describe('Authentication Routes', () => {
         })
         .expect(401)
         .end((err, res) => {
-          expect(res.text).to.equal('Invalid email address.\n');
+          expect(res.text).to.contain('Invalid email address.');
           done(err);
         });
     });
@@ -155,7 +155,7 @@ describe('Authentication Routes', () => {
         })
         .expect(401)
         .end((err, res) => {
-          expect(res.text).to.equal('Invalid password length.\n');
+          expect(res.text).to.contain('Invalid password length.');
           done(err);
         });
     });


### PR DESCRIPTION
On mac os node return simple string so the tests are valid.
But with linux express seems to decorate the errors msgs with html tags.
Which invalidate the tests.
![error-test-email](https://cloud.githubusercontent.com/assets/3765910/24516096/d4492310-1579-11e7-9ff8-41c8bc2e2c62.png)
