### PR TITLE
chore: update method-override

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,3 @@
 {
-  "exceptions": ["https://nodesecurity.io/advisories/130"]
+  "exceptions": ["https://nodesecurity.io/advisories/130", "https://nodesecurity.io/advisories/525", "https://nodesecurity.io/advisories/534"]
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jsonwebtoken": "^7.3.0",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
-    "method-override": "^2.3.7",
+    "method-override": "^2.3.10",
     "moment-timezone": "^0.5.13",
     "mongoose": "^4.9.1",
     "morgan": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,6 +1610,12 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -4168,14 +4174,14 @@ merge-stream@^1.0.0:
   dependencies:
     readable-stream "^2.0.1"
 
-method-override@^2.3.7:
-  version "2.3.9"
-  resolved "https://registry.yarnpkg.com/method-override/-/method-override-2.3.9.tgz#bd151f2ce34cf01a76ca400ab95c012b102d8f71"
+method-override@^2.3.10:
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/method-override/-/method-override-2.3.10.tgz#e3daf8d5dee10dd2dce7d4ae88d62bbee77476b4"
   dependencies:
-    debug "2.6.8"
+    debug "2.6.9"
     methods "~1.1.2"
-    parseurl "~1.3.1"
-    vary "~1.1.1"
+    parseurl "~1.3.2"
+    vary "~1.1.2"
 
 methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
@@ -4744,6 +4750,10 @@ parseuri@0.0.5:
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+
+parseurl@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
 passport-local@^1.0.0:
   version "1.0.0"
@@ -6343,6 +6353,10 @@ validate-npm-package-license@^3.0.1:
 vary@^1, vary@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
Fix for https://nodesecurity.io/advisories/528.